### PR TITLE
Fix issue with package manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,5 @@
+// swift-tools-version:5.7
+
 import PackageDescription
 
 let package = Package(
@@ -6,16 +8,18 @@ let package = Package(
         .library(
             name: "LocalServer",
             targets: ["LocalServer"]
-        ),
+        )
     ],
     targets: [
         .target(
             name: "LocalServer",
-            dependencies: []
+            dependencies: [],
+            path: "LocalServer/Source"
         ),
         .testTarget(
             name: "LocalServerTests",
-            dependencies: ["LocalServer"]
-        ),
+            dependencies: ["LocalServer"],
+            path: "LocalServerTests"
+        )
     ]
 )


### PR DESCRIPTION
Fixes issue #3.

Output of `swift package describe`:
```
Name: LocalServer
Manifest display name: LocalServer
Path: <dir>
Tools version: 5.7
Dependencies:
Platforms:
Products:
    Name: LocalServer
    Type:
        Library:
            automatic
    Targets:
        LocalServer

Targets:
    Name: LocalServerTests
    Type: test
    C99name: LocalServerTests
    Module type: SwiftTarget
    Path: LocalServerTests
    Sources:
        DataExtensionTests.swift
        StubResponseTests.swift
        StubServerTests.swift
        TestExtensions.swift
        UITestResponseTests.swift
        WKWebViewResponseTests.swift
    Target dependencies:
        LocalServer

    Name: LocalServer
    Type: library
    C99name: LocalServer
    Module type: SwiftTarget
    Path: LocalServer/Source
    Sources:
        DataExtension.swift
        Exchangeable.swift
        Router.swift
        StubResponse.swift
        StubServer.swift
        StubURLHTTPProtocol.swift
        StubURLSession.swift
        StubWKWebView.swift
        UITestResponse.swift
        UITestServer.swift
        UITestState.swift
    Product memberships:
        LocalServer
```